### PR TITLE
error struct: maintain the error code

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,56 @@
+package gphoto2go
+
+// #cgo pkg-config: libgphoto2
+// #include <gphoto2.h>
+import "C"
+import "fmt"
+
+const (
+	ErrModelNotFound = C.GP_ERROR_MODEL_NOT_FOUND
+)
+
+const (
+	errUnknown = "libgphoto2: unknown error"
+)
+
+type Error struct {
+	code    int
+	message string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("libgphoto2: [%d] %s", e.code, e.message)
+}
+
+func (e *Error) Code() int {
+	return e.code
+}
+
+func (e *Error) Message() string {
+	return e.message
+}
+
+func (e *Error) IsModelNotFound() bool {
+	return e.code == ErrModelNotFound
+}
+
+func cameraResultToError(code C.int) error {
+	if code == 0 {
+		return nil
+	}
+
+	str := C.GoString(C.gp_result_as_string(code))
+	if str == "" {
+		str = errUnknown
+	}
+
+	return &Error{
+		code:    int(code),
+		message: str,
+	}
+}
+
+// CameraResultToString func
+func CameraResultToString(err C.int) string {
+	return C.GoString(C.gp_result_as_string(err))
+}

--- a/gphoto2go.go
+++ b/gphoto2go.go
@@ -5,7 +5,6 @@ package gphoto2go
 // #include <stdlib.h>
 import "C"
 import (
-	"fmt"
 	"unsafe"
 )
 
@@ -73,16 +72,4 @@ func cameraListToMap(cameraList *C.CameraList) (map[string]string, int) {
 	}
 
 	return vals, 0
-}
-
-func cameraResultToError(err C.int) error {
-	if err != 0 {
-		return fmt.Errorf(C.GoString(C.gp_result_as_string(err)))
-	}
-	return nil
-}
-
-// CameraResultToString func
-func CameraResultToString(err C.int) string {
-	return C.GoString(C.gp_result_as_string(err))
 }


### PR DESCRIPTION
Allows users to handle errors in a cleaner way.

Is* boolean methods as opposed to comparing negative ints or strings.

We should probably add all error constants and provide a base Error.Is(Err int) method.

usecase:

my importer package allows registering custom importers, one of those is libgphoto2. The libgphoto2 importer only registers itself if a camera is connected. (!camera.Init().IsModelNotFound())